### PR TITLE
Add example of logging inside scheduled operation (reactive) #179

### DIFF
--- a/spring-boot-3-demo-app-reactive/src/main/java/io/github/mfvanek/spring/boot3/reactive/Application.java
+++ b/spring-boot-3-demo-app-reactive/src/main/java/io/github/mfvanek/spring/boot3/reactive/Application.java
@@ -9,9 +9,11 @@ package io.github.mfvanek.spring.boot3.reactive;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import reactor.tools.agent.ReactorDebugAgent;
 
 @SpringBootApplication
+@EnableScheduling
 public class Application {
 
     public static void main(String[] args) {

--- a/spring-boot-3-demo-app-reactive/src/main/java/io/github/mfvanek/spring/boot3/reactive/support/ScheduledLoggingTask.java
+++ b/spring-boot-3-demo-app-reactive/src/main/java/io/github/mfvanek/spring/boot3/reactive/support/ScheduledLoggingTask.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2020-2025. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/spring-boot-open-telemetry-demo
+ *
+ * Licensed under the Apache License 2.0
+ */
+
+package io.github.mfvanek.spring.boot3.reactive.support;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class ScheduledLoggingTask {
+
+    @Scheduled(fixedDelayString = "${app.scheduled-logger.delay-ms:60000}")
+    public void logHeartbeat() {
+        log.info("Scheduled heartbeat from reactive app");
+    }
+}
+
+


### PR DESCRIPTION
- Implements a scheduled logging example in the reactive app to address issue #179.
- Enables scheduling via @EnableScheduling in Application.
- Adds ScheduledLoggingTask with a single @Scheduled method that logs a heartbeat.
- Delay is configurable via app.scheduled-logger.delay-ms (default 60000 ms).

